### PR TITLE
Make README.md more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Available parameters:
 Now create user mapping and foreign tables:
 
     CREATE USER MAPPING FOR CURRENT_USER SERVER clickhouse_svr
-		OPTIONS (user 'default', password 'password');
+		OPTIONS (user 'default', password '');
 	IMPORT FOREIGN SCHEMA "kk" FROM SERVER clickhouse_svr INTO public;
 
 	SELECT bbl,tbea,bav,insertion_date FROM tax_bills_nyc LIMIT 5;


### PR DESCRIPTION
Make README.md more clear to help new comer get a quick start.

- add 'CREATE EXTENSION' statement
- add user name and password options for 'CREATE USER MAPPING'