### PR TITLE
add more date trunc options

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2352,12 +2352,18 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		char *trunctype = TextDatumGetCString(arg->constvalue);
 		if (strcmp(trunctype, "week") == 0)
 			appendStringInfoString(buf, "toMonday");
+		else if (strcmp(trunctype, "second") == 0)
+			appendStringInfoString(buf, "toStartOfSecond");
+		else if (strcmp(trunctype, "minute") == 0)
+			appendStringInfoString(buf, "toStartOfMinute");
 		else if (strcmp(trunctype, "hour") == 0)
 			appendStringInfoString(buf, "toStartOfHour");
 		else if (strcmp(trunctype, "day") == 0)
 			appendStringInfoString(buf, "toStartOfDay");
 		else if (strcmp(trunctype, "month") == 0)
 			appendStringInfoString(buf, "toStartOfMonth");
+		else if (strcmp(trunctype, "quarter") == 0)
+			appendStringInfoString(buf, "toStartOfQuarter");
 		else if (strcmp(trunctype, "year") == 0)
 			appendStringInfoString(buf, "toStartOfYear");
 		else


### PR DESCRIPTION
I've added some more `date_trunc` options since they are supported by default in different BI tools (such as Metabase) and the FDW wasn't working.

Let me know if this seems OK to you

Thanks!

cc. @ildus 