### PR TITLE
use IF NOT EXISTS to allow for incremental runs of IMPORT SCHEMA

### DIFF
--- a/src/pglink.c
+++ b/src/pglink.c
@@ -889,7 +889,7 @@ chfdw_construct_create_tables(ImportForeignSchemaStmt *stmt, ForeignServer *serv
 		}
 
 		initStringInfo(&buf);
-		appendStringInfo(&buf, "CREATE FOREIGN TABLE %s.%s (\n",
+		appendStringInfo(&buf, "CREATE FOREIGN TABLE IF NOT EXISTS %s.%s (\n",
 			stmt->local_schema, table_name);
 		query = psprintf("select name, type from system.columns where database='%s' and table='%s'", stmt->remote_schema, table_name);
 		table_def = conn.methods->simple_query(conn.conn, query);


### PR DESCRIPTION
The `IMPORT SCHEMA` runs pretty nicely (💓) but when you do a second run because you want to re-import new tables you have created in ClickHouse, it was failing due to trying to overwrite existing tables.

Adding the `IF NOT EXISTS` clause to the `CREATE FOREIGN TABLE` statement does the trick.

cc. @ildus 🙏