### PR TITLE
Patch parse datetime function

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2354,6 +2354,9 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	{
 		Const *arg = (Const *) linitial(node->args);
 		char *trunctype = TextDatumGetCString(arg->constvalue);
+		for(int i = 0; trunctype[i]; i++){
+		  str[i] = tolower(trunctype[i]);
+		}
 		if (strcmp(trunctype, "week") == 0)
 			appendStringInfoString(buf, "toMonday");
 		else if (strcmp(trunctype, "second") == 0)
@@ -2383,6 +2386,9 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 	{
 		Const *arg = (Const *) linitial(node->args);
 		char *parttype = TextDatumGetCString(arg->constvalue);
+		for(int i = 0; parttype[i]; i++){
+		  str[i] = tolower(parttype[i]);
+		}
 
 		if (strcmp(parttype, "day") == 0)
 			appendStringInfoString(buf, "toDayOfMonth");

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2355,7 +2355,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		Const *arg = (Const *) linitial(node->args);
 		char *trunctype = TextDatumGetCString(arg->constvalue);
 		for(int i = 0; trunctype[i]; i++){
-		  str[i] = tolower(trunctype[i]);
+		  trunctype[i] = tolower(trunctype[i]);
 		}
 		if (strcmp(trunctype, "week") == 0)
 			appendStringInfoString(buf, "toMonday");
@@ -2387,7 +2387,7 @@ deparseFuncExpr(FuncExpr *node, deparse_expr_cxt *context)
 		Const *arg = (Const *) linitial(node->args);
 		char *parttype = TextDatumGetCString(arg->constvalue);
 		for(int i = 0; parttype[i]; i++){
-		  str[i] = tolower(parttype[i]);
+		  parttype[i] = tolower(parttype[i]);
 		}
 
 		if (strcmp(parttype, "day") == 0)


### PR DESCRIPTION
fix bug can not work with tableau filter date range
old code not work: SELECT DATE_TRUNC('YEAR', col_name)