### PR TITLE
Case insensitive date_trunc, date_part; toStartOfSeconds needs DateTi…

### DIFF
--- a/src/pglink.c
+++ b/src/pglink.c
@@ -412,7 +412,7 @@ extend_insert_query(ch_http_insert_state *state, TupleTableSlot *slot)
 			{
 				/* we expect DateTime on other side */
 				char *extval = DatumGetCString(DirectFunctionCall1(ch_time_out, value));
-				appendStringInfo(&state->sql, "0001-01-01 %s", extval);
+				appendStringInfo(&state->sql, "1970-01-01 %s", extval);
 				pfree(extval);
 				break;
 			}

--- a/tests/expected/binary_inserts.out
+++ b/tests/expected/binary_inserts.out
@@ -34,7 +34,7 @@ SELECT clickhousedb_raw_query('CREATE TABLE regression.uints (
 
 SELECT clickhousedb_raw_query('CREATE TABLE regression.floats (
     c1 Float32, c2 Float64
-) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
  clickhousedb_raw_query 
 ------------------------

--- a/tests/expected/functions.out
+++ b/tests/expected/functions.out
@@ -233,11 +233,11 @@ SELECT uniq_exact(a) FILTER(WHERE b>1) FROM t1;
           1
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
                                                                                 QUERY PLAN                                                                                
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_trunc('day'::text, timezone('UTC'::text, c)))
+   Output: (date_trunc('dAy'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t1)
    Remote SQL: SELECT toStartOfDay(toTimeZone(c, 'UTC')) FROM regression.t1 GROUP BY (toStartOfDay(toTimeZone(c, 'UTC'))) ORDER BY toStartOfDay(toTimeZone(c, 'UTC')) ASC
 (4 rows)
@@ -329,31 +329,47 @@ SELECT extract('dow' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER 
   3
 (2 rows)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('minute' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('minuTe' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_part('minute'::text, timezone('UTC'::text, c)))
+   Output: (date_part('minuTe'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toMinute(toTimeZone(c, 'UTC')) FROM regression.t1 GROUP BY (toMinute(toTimeZone(c, 'UTC'))) ORDER BY toMinute(toTimeZone(c, 'UTC')) ASC
 (4 rows)
 
-SELECT extract('minute' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT extract('minuTe' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
  d1 
 ----
   0
 (1 row)
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('epoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+                                                                                                              QUERY PLAN                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Foreign Scan
+   Output: (date_trunc('SeCond'::text, timezone('UTC'::text, c)))
+   Relations: Aggregate on (t1)
+   Remote SQL: SELECT toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) FROM regression.t1 GROUP BY (toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1))) ORDER BY toStartOfSecond(toDateTime64(toTimeZone(c, 'UTC'), 1)) ASC
+(4 rows)
+
+SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+           d1           
+------------------------
+ 2019-01-01 10:00:00-08
+ 2019-01-02 10:00:00-08
+(2 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('ePoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
                                                                                     QUERY PLAN                                                                                     
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Foreign Scan
-   Output: (date_part('epoch'::text, timezone('UTC'::text, c)))
+   Output: (date_part('ePoch'::text, timezone('UTC'::text, c)))
    Relations: Aggregate on (t2)
    Remote SQL: SELECT toUnixTimestamp(toTimeZone(c, 'UTC')) FROM regression.t1 GROUP BY (toUnixTimestamp(toTimeZone(c, 'UTC'))) ORDER BY toUnixTimestamp(toTimeZone(c, 'UTC')) ASC
 (4 rows)
 
-SELECT extract('epoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT extract('ePoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
      d1     
 ------------
  1546336800

--- a/tests/sql/binary_inserts.sql
+++ b/tests/sql/binary_inserts.sql
@@ -17,7 +17,7 @@ SELECT clickhousedb_raw_query('CREATE TABLE regression.uints (
 
 SELECT clickhousedb_raw_query('CREATE TABLE regression.floats (
     c1 Float32, c2 Float64
-) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1);
+) ENGINE = MergeTree PARTITION BY c1 ORDER BY (c1) SETTINGS allow_floating_point_partition_key=1;
 ');
 
 SELECT clickhousedb_raw_query('CREATE TABLE regression.null_ints (

--- a/tests/sql/functions.sql
+++ b/tests/sql/functions.sql
@@ -78,7 +78,7 @@ SELECT uniq_exact(a) FROM t1;
 EXPLAIN (VERBOSE, COSTS OFF) SELECT uniq_exact(a) FILTER(WHERE b>1) FROM t1;
 SELECT uniq_exact(a) FILTER(WHERE b>1) FROM t1;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('dAy', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('day', c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
@@ -96,11 +96,14 @@ SELECT extract('doy' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('dow' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 SELECT extract('dow' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('minute' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-SELECT extract('minute' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('minuTe' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT extract('minuTe' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 
-EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('epoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
-SELECT extract('epoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+EXPLAIN (VERBOSE, COSTS OFF) SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+SELECT date_trunc('SeCond', c at time zone 'UTC') as d1 FROM t1 GROUP BY d1 ORDER BY d1;
+
+EXPLAIN (VERBOSE, COSTS OFF) SELECT extract('ePoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
+SELECT extract('ePoch' from c at time zone 'UTC') as d1 FROM t2 GROUP BY d1 ORDER BY d1;
 
 EXPLAIN (VERBOSE, COSTS OFF) SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;
 SELECT ltrim(val) AS a, btrim(val) AS b, rtrim(val) AS c FROM t4 GROUP BY a,b,c ORDER BY a;


### PR DESCRIPTION
This PR
* makes comparison of time units (SECONDS, MINUTES etc.) in functions date_trunc, date_part case insensitive (based on #52)
* add toDateTime64(col, 1) conversion when using seconds unit as it is required type for toStartOfSeconds clickhouse function


this bug make it can not work with tableau filter date range
and cannot work with google datastudio filter