### PR TITLE
Use proper suffix for shared library file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,7 @@ endif()
 set_target_properties (clickhouse_fdw PROPERTIES
   OUTPUT_NAME "clickhouse_fdw"
   PREFIX ""
+  SUFFIX ${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
 set_target_properties(clickhouse_fdw PROPERTIES
 	BUILD_WITH_INSTALL_RPATH TRUE


### PR DESCRIPTION
On macOS, the file was named `clickhouse_fdw.so` but should be `clickhouse_fdw.dylib`. This change seems to fix the issue by setting the suffix to the platform default.